### PR TITLE
add-js-alert - Add js alert

### DIFF
--- a/Oahu.xcodeproj/project.pbxproj
+++ b/Oahu.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		8B00B8011C1EFCEB00A9678D /* Interceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B00B8001C1EFCEB00A9678D /* Interceptor.swift */; };
 		8B00B8051C1F25E800A9678D /* OahuEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B00B8041C1F25E800A9678D /* OahuEvaluator.swift */; };
 		8B00B8071C1F261800A9678D /* EvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B00B8061C1F261800A9678D /* EvaluatorTests.swift */; };
+		8B11C3931C7CE4D000707F4F /* AlertJSDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B11C3921C7CE4CF00707F4F /* AlertJSDelegate.swift */; };
 		8B2F35E71C233E4200C5BBE2 /* ScriptMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B2F35E61C233E4200C5BBE2 /* ScriptMessageHandler.swift */; };
 		8B2F35E91C285A5000C5BBE2 /* CookieHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B2F35E81C285A5000C5BBE2 /* CookieHandler.swift */; };
 		8B4CB3641C2072F5005D95A7 /* OahuDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4CB3631C2072F5005D95A7 /* OahuDelegate.swift */; };
@@ -38,6 +39,7 @@
 		8B00B8001C1EFCEB00A9678D /* Interceptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Interceptor.swift; sourceTree = "<group>"; };
 		8B00B8041C1F25E800A9678D /* OahuEvaluator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OahuEvaluator.swift; sourceTree = "<group>"; };
 		8B00B8061C1F261800A9678D /* EvaluatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EvaluatorTests.swift; sourceTree = "<group>"; };
+		8B11C3921C7CE4CF00707F4F /* AlertJSDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlertJSDelegate.swift; sourceTree = "<group>"; };
 		8B2F35E61C233E4200C5BBE2 /* ScriptMessageHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScriptMessageHandler.swift; sourceTree = "<group>"; };
 		8B2F35E81C285A5000C5BBE2 /* CookieHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CookieHandler.swift; sourceTree = "<group>"; };
 		8B4CB3631C2072F5005D95A7 /* OahuDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OahuDelegate.swift; sourceTree = "<group>"; };
@@ -106,6 +108,7 @@
 				8B4CB3631C2072F5005D95A7 /* OahuDelegate.swift */,
 				8B00B8041C1F25E800A9678D /* OahuEvaluator.swift */,
 				8B8A7EE01C18BFE2003466D6 /* Extensions */,
+				8B11C3921C7CE4CF00707F4F /* AlertJSDelegate.swift */,
 			);
 			path = Oahu;
 			sourceTree = "<group>";
@@ -246,6 +249,7 @@
 				8B8A7EDE1C18BFDC003466D6 /* Oahu.swift in Sources */,
 				8B4CB3661C207332005D95A7 /* ExtOahu.swift in Sources */,
 				8B4CB3641C2072F5005D95A7 /* OahuDelegate.swift in Sources */,
+				8B11C3931C7CE4D000707F4F /* AlertJSDelegate.swift in Sources */,
 				8B8A7EDC1C18BFDC003466D6 /* ExtArray.swift in Sources */,
 				8B2F35E91C285A5000C5BBE2 /* CookieHandler.swift in Sources */,
 				8B00B8051C1F25E800A9678D /* OahuEvaluator.swift in Sources */,

--- a/Oahu/AlertJSDelegate.swift
+++ b/Oahu/AlertJSDelegate.swift
@@ -4,24 +4,24 @@ import WebKit
 class AlertJSDelegate: NSObject, WKUIDelegate {
     let rootViewController: UIViewController
 
-    init(rootViewController: UIViewController) {
+    init?(rootViewController: UIViewController?) {
         self.rootViewController = rootViewController
     }
 
     func webView(webView: WKWebView, runJavaScriptAlertPanelWithMessage message: String, initiatedByFrame frame: WKFrameInfo, completionHandler: () -> Void) {
-        AlertManager().presentAlertOnController(self.rootViewController, title: "Alert", message: message, handler: completionHandler)
+        AlertJS().presentAlertOnController(self.rootViewController, title: "Alert", message: message, handler: completionHandler)
     }
 
     func webView(webView: WKWebView, runJavaScriptConfirmPanelWithMessage message: String, initiatedByFrame frame: WKFrameInfo, completionHandler: (Bool) -> Void) {
-        AlertManager().presentConfirmOnController(self.rootViewController, title: "Confirm", message: message, handler: completionHandler)
+        AlertJS().presentConfirmOnController(self.rootViewController, title: "Confirm", message: message, handler: completionHandler)
     }
 
     func webView(webView: WKWebView, runJavaScriptTextInputPanelWithPrompt prompt: String, defaultText: String?, initiatedByFrame frame: WKFrameInfo, completionHandler: (String?) -> Void) {
-        AlertManager
+        AlertJS().presentPromptOnController(self.rootViewController, title: "Prompt", message: prompt, defaultText: defaultText, completionHandler: completionHandler)
     }
 }
 
-struct AlertManager {
+struct AlertJS {
     func presentAlertOnController(parentController: UIViewController, title: String, message: String, handler: () -> ()) {
         let alert = UIAlertController(title: title, message: message, preferredStyle: UIAlertControllerStyle.Alert)
 
@@ -46,7 +46,7 @@ struct AlertManager {
         parentController.presentViewController(alert, animated: true, completion: nil)
     }
 
-    func presentPromptOnController(parentController: UIViewController, title: String, message: String, defaultText: String, completionHandler: (String?) -> ()) {
+    func presentPromptOnController(parentController: UIViewController, title: String, message: String, defaultText: String?, completionHandler: (String?) -> ()) {
         let alert = UIAlertController(title: title, message: message, preferredStyle: UIAlertControllerStyle.Alert)
         alert.addTextFieldWithConfigurationHandler { (textFilter) -> Void in
             textFilter.text = defaultText

--- a/Oahu/AlertJSDelegate.swift
+++ b/Oahu/AlertJSDelegate.swift
@@ -1,0 +1,67 @@
+import UIKit
+import WebKit
+
+class AlertJSDelegate: NSObject, WKUIDelegate {
+    let rootViewController: UIViewController
+
+    init(rootViewController: UIViewController) {
+        self.rootViewController = rootViewController
+    }
+
+    func webView(webView: WKWebView, runJavaScriptAlertPanelWithMessage message: String, initiatedByFrame frame: WKFrameInfo, completionHandler: () -> Void) {
+        AlertManager().presentAlertOnController(self.rootViewController, title: "Alert", message: message, handler: completionHandler)
+    }
+
+    func webView(webView: WKWebView, runJavaScriptConfirmPanelWithMessage message: String, initiatedByFrame frame: WKFrameInfo, completionHandler: (Bool) -> Void) {
+        AlertManager().presentConfirmOnController(self.rootViewController, title: "Confirm", message: message, handler: completionHandler)
+    }
+
+    func webView(webView: WKWebView, runJavaScriptTextInputPanelWithPrompt prompt: String, defaultText: String?, initiatedByFrame frame: WKFrameInfo, completionHandler: (String?) -> Void) {
+        AlertManager
+    }
+}
+
+struct AlertManager {
+    func presentAlertOnController(parentController: UIViewController, title: String, message: String, handler: () -> ()) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: UIAlertControllerStyle.Alert)
+
+        alert.addAction(UIAlertAction(title: title, style: UIAlertActionStyle.Cancel, handler: { (action) -> Void in
+            handler()
+        }))
+
+        parentController.presentViewController(alert, animated: true, completion: nil)
+    }
+
+    func presentConfirmOnController(parentController: UIViewController, title: String, message: String, handler: (Bool) -> ()) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: UIAlertControllerStyle.Alert)
+
+        alert.addAction(UIAlertAction(title: title, style: UIAlertActionStyle.Cancel, handler: { (action) -> Void in
+            handler(true)
+        }))
+
+        alert.addAction(UIAlertAction(title: title, style: UIAlertActionStyle.Cancel, handler: { (action) -> Void in
+            handler(false)
+        }))
+
+        parentController.presentViewController(alert, animated: true, completion: nil)
+    }
+
+    func presentPromptOnController(parentController: UIViewController, title: String, message: String, defaultText: String, completionHandler: (String?) -> ()) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: UIAlertControllerStyle.Alert)
+        alert.addTextFieldWithConfigurationHandler { (textFilter) -> Void in
+            textFilter.text = defaultText
+        }
+
+        alert.addAction(UIAlertAction(title: "OK", style: UIAlertActionStyle.Default, handler: { (action) -> Void in
+            if let textFields = alert.textFields {
+                completionHandler(textFields[0].text)
+            }
+        }))
+
+        alert.addAction(UIAlertAction(title: "Cancel", style: UIAlertActionStyle.Cancel, handler: { (action) -> Void in
+            completionHandler(nil)
+        }))
+
+        parentController.presentViewController(alert, animated: true, completion: nil)
+    }
+}

--- a/Oahu/AlertJSDelegate.swift
+++ b/Oahu/AlertJSDelegate.swift
@@ -4,7 +4,7 @@ import WebKit
 class AlertJSDelegate: NSObject, WKUIDelegate {
     let rootViewController: UIViewController
 
-    init?(rootViewController: UIViewController?) {
+    init(rootViewController: UIViewController) {
         self.rootViewController = rootViewController
     }
 

--- a/Oahu/AlertJSDelegate.swift
+++ b/Oahu/AlertJSDelegate.swift
@@ -25,7 +25,7 @@ struct AlertJS {
     func presentAlertOnController(parentController: UIViewController, title: String, message: String, handler: () -> ()) {
         let alert = UIAlertController(title: title, message: message, preferredStyle: UIAlertControllerStyle.Alert)
 
-        alert.addAction(UIAlertAction(title: title, style: UIAlertActionStyle.Cancel, handler: { (action) -> Void in
+        alert.addAction(UIAlertAction(title: "OK", style: UIAlertActionStyle.Cancel, handler: { (action) -> Void in
             handler()
         }))
 
@@ -35,11 +35,11 @@ struct AlertJS {
     func presentConfirmOnController(parentController: UIViewController, title: String, message: String, handler: (Bool) -> ()) {
         let alert = UIAlertController(title: title, message: message, preferredStyle: UIAlertControllerStyle.Alert)
 
-        alert.addAction(UIAlertAction(title: title, style: UIAlertActionStyle.Cancel, handler: { (action) -> Void in
+        alert.addAction(UIAlertAction(title: "OK", style: UIAlertActionStyle.Default, handler: { (action) -> Void in
             handler(true)
         }))
 
-        alert.addAction(UIAlertAction(title: title, style: UIAlertActionStyle.Cancel, handler: { (action) -> Void in
+        alert.addAction(UIAlertAction(title: "Cancel", style: UIAlertActionStyle.Cancel, handler: { (action) -> Void in
             handler(false)
         }))
 

--- a/Oahu/Oahu.swift
+++ b/Oahu/Oahu.swift
@@ -6,7 +6,8 @@ public class Oahu: NSObject {
     private(set) var interceptor: Interceptor?
     public weak var oahuDelegate: OahuDelegate?
     private let webViewConfiguration = Configuration()
-    
+    private var delegate: AlertJSDelegate?
+
     public var javaScriptHandlers:[ScriptMessageHandler]? {
         didSet {
             webViewConfiguration.messageHandlers = javaScriptHandlers
@@ -24,7 +25,8 @@ public class Oahu: NSObject {
         super.init()
         wkWebView.navigationDelegate = self
         if let viewController = viewController {
-            wkWebView.UIDelegate = AlertJSDelegate(rootViewController: viewController)
+            self.delegate = AlertJSDelegate(rootViewController: viewController)
+            wkWebView.UIDelegate = self.delegate
         }
     }
 

--- a/Oahu/Oahu.swift
+++ b/Oahu/Oahu.swift
@@ -23,7 +23,7 @@ public class Oahu: NSObject {
 
         super.init()
         wkWebView.navigationDelegate = self
-        wkWebView.UIDelegate = AlertJSDelegate()
+        wkWebView.UIDelegate = AlertJSDelegate(rootViewController: view.window!.rootViewController)
     }
 
     public func loadRequest(url: String) {

--- a/Oahu/Oahu.swift
+++ b/Oahu/Oahu.swift
@@ -23,6 +23,7 @@ public class Oahu: NSObject {
 
         super.init()
         wkWebView.navigationDelegate = self
+        wkWebView.UIDelegate = AlertJSDelegate()
     }
 
     public func loadRequest(url: String) {

--- a/Oahu/Oahu.swift
+++ b/Oahu/Oahu.swift
@@ -13,7 +13,7 @@ public class Oahu: NSObject {
         }
     }
 
-    public init(forView view: UIView, allowsBackForwardNavigationGestures: Bool, interceptor: Interceptor? = nil) {
+    public init(forView view: UIView, allowsBackForwardNavigationGestures: Bool, interceptor: Interceptor? = nil, viewController: UIViewController? = nil) {
         wkWebView = WKWebView(frame: view.frame, configuration: webViewConfiguration.config)
 
         self.interceptor = interceptor
@@ -23,7 +23,9 @@ public class Oahu: NSObject {
 
         super.init()
         wkWebView.navigationDelegate = self
-        wkWebView.UIDelegate = AlertJSDelegate(rootViewController: view.window!.rootViewController)
+        if let viewController = viewController {
+            wkWebView.UIDelegate = AlertJSDelegate(rootViewController: viewController)
+        }
     }
 
     public func loadRequest(url: String) {


### PR DESCRIPTION
To test:
- [x] if webpage show `javascript` alert, Oahu should intercept it and show native dialog